### PR TITLE
fix: use `lodash.template` directly to compile template

### DIFF
--- a/packages/nuxt-kit/package.json
+++ b/packages/nuxt-kit/package.json
@@ -27,11 +27,13 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.9.0",
+    "lodash-es": "^4.17.21",
     "pathe": "^1.1.1"
   },
   "devDependencies": {
     "@lyonkit/ts-client": "workspace:^",
     "@nuxt/module-builder": "^0.5.5",
-    "@nuxt/schema": "^3.9.0"
+    "@nuxt/schema": "^3.9.0",
+    "@types/lodash-es": "^4.17.12"
   }
 }

--- a/packages/nuxt-kit/src/module.ts
+++ b/packages/nuxt-kit/src/module.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { template } from 'lodash-es'
 import {
   addImports,
   addPluginTemplate,
@@ -45,7 +47,10 @@ export default <NuxtModule<ModuleOptions>> defineNuxtModule<ModuleOptions>({
     // Inject options via virtual template
     nuxt.options.alias['#lyonkit'] = addTemplate({
       filename: 'lyonkit.mjs',
-      src: resolveRuntimeModule('./templates/composable'),
+      getContents({ options }) {
+        const contents = readFileSync(resolveRuntimeModule('./templates/composable'), 'utf-8')
+        return template(contents)({ options })
+      },
       options: {
         config: opts,
       },

--- a/packages/nuxt-kit/src/module.ts
+++ b/packages/nuxt-kit/src/module.ts
@@ -58,7 +58,10 @@ export default <NuxtModule<ModuleOptions>> defineNuxtModule<ModuleOptions>({
 
     addPluginTemplate({
       filename: 'lyonkit-plugin.mjs',
-      src: resolveRuntimeModule('./templates/plugin'),
+      getContents({ options }) {
+        const contents = readFileSync(resolveRuntimeModule('./templates/plugin'), 'utf-8')
+        return template(contents)({ options })
+      },
       options: {
         apiKey: opts.apiKey,
         readOnly: opts.readOnly ?? false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       standard-version:
         specifier: ^9.5.0
         version: 9.5.0
@@ -3455,6 +3458,10 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-locate: 5.0.0
+
+  /lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
 
   /lodash.ismatch@4.4.0:
     resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      lodash-es:
-        specifier: ^4.17.21
-        version: 4.17.21
       standard-version:
         specifier: ^9.5.0
         version: 9.5.0
@@ -36,6 +33,9 @@ importers:
       '@nuxt/kit':
         specifier: ^3.9.0
         version: 3.9.0(rollup@3.29.4)
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       pathe:
         specifier: ^1.1.1
         version: 1.1.1
@@ -49,6 +49,9 @@ importers:
       '@nuxt/schema':
         specifier: ^3.9.0
         version: 3.9.0(rollup@3.29.4)
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
 
   packages/ts-client:
     dependencies:
@@ -1045,6 +1048,16 @@ packages:
 
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+    dev: true
+
+  /@types/lodash-es@4.17.12:
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+    dependencies:
+      '@types/lodash': 4.17.0
+    dev: true
+
+  /@types/lodash@4.17.0:
+    resolution: {integrity: sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==}
     dev: true
 
   /@types/mdast@3.0.15:


### PR DESCRIPTION
We are going to be removing support for [compiling templates from disk using `lodash.template`](https://github.com/nuxt/nuxt/issues/25332) in Nuxt v4. This is a PR to move lodash usage directly into the module to avoid breaking it on Nuxt 4.

It would also be possible to avoid using it entirely, which I would _strongly_ recommend, either:
* using a custom function to handle the replacement, such as in https://github.com/nuxt-modules/color-mode/pull/240
* or moving the string interpolation logic directly into `getContents`
